### PR TITLE
chore: s3 deploy fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,11 +3,15 @@ name: Deploy
 on:
   push:
     branches:
-      - main
+      - 'main'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      API_URL: ${{ secrets.API_URL }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -18,13 +22,11 @@ jobs:
       - name: Build
         run: yarn build
       - name: Deploy
-        uses: TimekillerTK/s3-sync-action@master
+        uses: reggionick/s3-deploy@v3
         with:
-          args: --acl private --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ${{ secrets.S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          SOURCE_DIR: 'build'  
+          folder: build
+          bucket: ${{ secrets.S3_BUCKET }}
+          bucket-region: ${{ secrets.AWS_REGION }}
+          dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          invalidation: /*
+          private: true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,9 @@ module.exports = (env, { mode } = { mode: MODE_PRODUCTION }) => ({
     extensions: ['*', '.js', '.jsx', '.tsx', '.ts']
   },
   plugins: [
-    new Dotenv(),
+    new Dotenv({
+      systemvars: true
+    }),
     new webpack.ProvidePlugin({
       React: 'react'
     }),


### PR DESCRIPTION
I went back to the `reggionick/s3-deploy@v3` action. Setting `private: true` did the trick.

Also, I had to set `systemvars: true` in [dotenv-webpack](https://github.com/mrsteele/dotenv-webpack#properties) plugin to be able to use vars set in GHA environment.

I did a [sample build](https://github.com/copotrzebne-pl/copotrzebne-frontend/actions/runs/1987974901) and it worked. Cache was invalidated and the app is using correct api url.